### PR TITLE
Removendo espaços na validação de preenchimento do campo de pergunta.

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -16,7 +16,7 @@ document
   .getElementById("btn-generate-question")
   .addEventListener("click", (ev) => {
     question = document.getElementById("input-question").value;
-    if (!question || question == "") {
+    if (!question || question.trim() == "") {
       alert("Por favor, informe a pergunta desejada");
       return;
     }


### PR DESCRIPTION
Adicionado o método trim() na validação do preenchimento do campo de pergunta, pois, se o usuário adicionar somente espaços, ele consegue gerar a página de perguntas, sem nenhuma pergunta.

Antes:
![image](https://github.com/do-you-want/do-you-want.github.io/assets/90285244/dcd876ff-3de3-441d-8e64-72ac802ffd53)
![image](https://github.com/do-you-want/do-you-want.github.io/assets/90285244/d5385293-110e-4897-8baa-93aedcd92e11)


Depois:
![image](https://github.com/do-you-want/do-you-want.github.io/assets/90285244/ec87de62-1eb3-48b4-8861-ea2e04d123d7)
